### PR TITLE
ECCUBE2Downloads対応: ダウンロード商品のsale_type_idを222に書き換え

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -85,7 +85,7 @@ jobs:
         env:
           PLUGIN_CODE: ${{ matrix.plugin_code }}
         run: |
-          tar cvzf ${GITHUB_WORKSPACE}/${PLUGIN_CODE}.tar.gz ./*
+          tar cvzf ${GITHUB_WORKSPACE}/${PLUGIN_CODE}.tar.gz --exclude=./ECCUBE2Downloads ./*
           cd ${GITHUB_WORKSPACE}/ECCUBE2Downloads && tar cvzf ${GITHUB_WORKSPACE}/ECCUBE2Downloads.tar.gz ./*
 
       - name: Setup mock-package-api

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -74,11 +74,19 @@ jobs:
         with:
           php-version: ${{ matrix.php }}
 
+      - name: Checkout ECCUBE2Downloads
+        uses: actions/checkout@v3
+        with:
+          repository: "nobuhiko/ECCUBE2Downloads"
+          ref: "main"
+          path: "ECCUBE2Downloads"
+
       - name: Archive Plugin
         env:
           PLUGIN_CODE: ${{ matrix.plugin_code }}
         run: |
           tar cvzf ${GITHUB_WORKSPACE}/${PLUGIN_CODE}.tar.gz ./*
+          cd ${GITHUB_WORKSPACE}/ECCUBE2Downloads && tar cvzf ${GITHUB_WORKSPACE}/ECCUBE2Downloads.tar.gz ./*
 
       - name: Setup mock-package-api
         env:
@@ -86,6 +94,7 @@ jobs:
         run: |
           mkdir -p /tmp/repos
           cp ${GITHUB_WORKSPACE}/${PLUGIN_CODE}.tar.gz /tmp/repos/${PLUGIN_CODE}.tgz
+          cp ${GITHUB_WORKSPACE}/ECCUBE2Downloads.tar.gz /tmp/repos/ECCUBE2Downloads.tgz
             docker run --name package-api -d -v /tmp/repos:/repos -e MOCK_REPO_DIR=/repos -p 8080:8080 eccube/mock-package-api:composer2
 
       - name: Checkout EC-CUBE
@@ -135,6 +144,9 @@ jobs:
         working-directory: "ec-cube"
         run: |
           bin/console doctrine:query:sql "update dtb_base_info set authentication_key='dummy'"
+          bin/console eccube:composer:require ec-cube/eccube2downloads
+          bin/console cache:clear --no-warmup
+          bin/console eccube:plugin:enable --code=ECCUBE2Downloads
           bin/console eccube:composer:require ec-cube/datamigration43
           bin/console cache:clear --no-warmup
           bin/console eccube:plugin:enable --code=${PLUGIN_CODE}

--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -472,6 +472,24 @@ class ConfigController extends AbstractController
         if (file_exists($csvDir . $product_db_name . '.csv') && filesize($csvDir . $product_db_name . '.csv') > 0) {
             $platform = $this->dataMigrationService->begin($em, "Product");
 
+            // ECCUBE2Downloads がインストール済みの場合、ダウンロード商品の product_type_id を検出
+            if (file_exists($csvDir . 'mtb_product_type.csv') && $this->dataMigrationService->isPluginInstalled($em, 'ECCUBE2Downloads')) {
+                $csvFile = $csvDir . 'mtb_product_type.csv';
+                if (($handle = fopen($csvFile, 'r')) !== false) {
+                    $key = fgetcsv($handle);
+                    $key = array_filter(array_map('trim', $key));
+                    while (($row = fgetcsv($handle)) !== false) {
+                        $data = array_combine($key, $row);
+                        $name = $data['name'] ?? '';
+                        if (mb_strpos($name, 'ダウンロード') !== false) {
+                            $this->downloadProductTypeId = (int)($data['id'] ?? 0);
+                            break;
+                        }
+                    }
+                    fclose($handle);
+                }
+            }
+
             // 2.11系の処理
             if (file_exists($csvDir . 'dtb_class_combination.csv')) {
                 $this->fix211classCombination($em, $platform, $csvDir);
@@ -508,23 +526,6 @@ class ConfigController extends AbstractController
                 $this->saveProductImage($em);
             }
             if (file_exists($csvDir . 'mtb_product_type.csv')) {
-                // ECCUBE2Downloads がインストール済みの場合、ダウンロード商品の product_type_id を検出
-                if ($this->dataMigrationService->isPluginInstalled($em, 'ECCUBE2Downloads')) {
-                    $csvFile = $csvDir . 'mtb_product_type.csv';
-                    if (file_exists($csvFile) && ($handle = fopen($csvFile, 'r')) !== false) {
-                        $key = fgetcsv($handle);
-                        $key = array_filter(array_map('trim', $key));
-                        while (($row = fgetcsv($handle)) !== false) {
-                            $data = array_combine($key, $row);
-                            $name = $data['name'] ?? '';
-                            if (mb_strpos($name, 'ダウンロード') !== false) {
-                                $this->downloadProductTypeId = (int)($data['id'] ?? 0);
-                                break;
-                            }
-                        }
-                        fclose($handle);
-                    }
-                }
                 // デフォルト判定により discriminator / rank->sort_no マッピングは upsertMaster 内で自動適用
                 $this->upsertMaster($em, $csvDir, 'mtb_product_type', 'mtb_sale_type', true);
             }

--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -50,6 +50,8 @@ class ConfigController extends AbstractController
     protected $customer_point = [];
     protected $memberIdSet = null; // array<int,bool>
     protected $missingCreatorIds = []; // array<int,bool>
+    /** @var int|null ECCUBE2Downloads用: 2.xのダウンロード商品 product_type_id */
+    protected $downloadProductTypeId = null;
 
     /**
      * constructor.
@@ -506,6 +508,23 @@ class ConfigController extends AbstractController
                 $this->saveProductImage($em);
             }
             if (file_exists($csvDir . 'mtb_product_type.csv')) {
+                // ECCUBE2Downloads がインストール済みの場合、ダウンロード商品の product_type_id を検出
+                if ($this->dataMigrationService->isPluginInstalled($em, 'ECCUBE2Downloads')) {
+                    $csvFile = $csvDir . 'mtb_product_type.csv';
+                    if (file_exists($csvFile) && ($handle = fopen($csvFile, 'r')) !== false) {
+                        $key = fgetcsv($handle);
+                        $key = array_filter(array_map('trim', $key));
+                        while (($row = fgetcsv($handle)) !== false) {
+                            $data = array_combine($key, $row);
+                            $name = $data['name'] ?? '';
+                            if (mb_strpos($name, 'ダウンロード') !== false) {
+                                $this->downloadProductTypeId = (int)($data['id'] ?? 0);
+                                break;
+                            }
+                        }
+                        fclose($handle);
+                    }
+                }
                 // デフォルト判定により discriminator / rank->sort_no マッピングは upsertMaster 内で自動適用
                 $this->upsertMaster($em, $csvDir, 'mtb_product_type', 'mtb_sale_type', true);
             }
@@ -714,7 +733,12 @@ class ConfigController extends AbstractController
 
                             // ---> dtb_product_class
                         } elseif ($column == 'sale_type_id') {
-                            $value[$column] = isset($data['product_type_id']) ? $data['product_type_id'] : 1;
+                            $productTypeId = isset($data['product_type_id']) ? (int)$data['product_type_id'] : 1;
+                            if ($this->downloadProductTypeId && $productTypeId === $this->downloadProductTypeId) {
+                                $value[$column] = 222; // ECCUBE2Downloads の販売種別ID
+                            } else {
+                                $value[$column] = $productTypeId;
+                            }
                         } elseif ($column == 'class_category_id1') {
                             $value[$column] = !empty($data['classcategory_id1']) ? $data['classcategory_id1'] : null;
 
@@ -1690,7 +1714,12 @@ class ConfigController extends AbstractController
 
                             // --> deliv
                         } elseif ($column == 'sale_type_id') {
-                            $value[$column] = isset($data['product_type_id']) ? $data['product_type_id'] : 1;
+                            $productTypeId = isset($data['product_type_id']) ? (int)$data['product_type_id'] : 1;
+                            if ($this->downloadProductTypeId && $productTypeId === $this->downloadProductTypeId) {
+                                $value[$column] = 222; // ECCUBE2Downloads の販売種別ID
+                            } else {
+                                $value[$column] = $productTypeId;
+                            }
                         } elseif ($column == 'description') {
                             $value[$column] = isset($data['remark']) ? $data['remark'] : null;
                         } elseif ($column == 'delivery_id') {

--- a/README.md
+++ b/README.md
@@ -1,97 +1,78 @@
 # データ移行プラグイン for EC-CUBE4
 
-EC-CUBE 2~4.1 のバックアップデータを利用して、4.3 系へのデータ移行を行うプラグイン
+EC-CUBE 2.x / 3.x / 4.0 / 4.1 のバックアップデータを利用して、EC-CUBE 4.3 系へデータ移行を行うプラグインです。
 
 - https://www.ec-cube.net/products/detail.php?product_id=2091
 - https://www.ec-cube.net/products/detail.php?product_id=2479
 - https://www.ec-cube.net/products/detail.php?product_id=2931
 
-## :sunny: 移行出来るデータ
+## 移行できるデータ
 
-### 会員データ
+| カテゴリ | テーブル | 備考 |
+|---|---|---|
+| **会員** | dtb_customer, dtb_customer_address, mtb_sex, mtb_job | |
+| **管理者** | dtb_member, mtb_authority | |
+| **商品** | dtb_product, dtb_product_class, dtb_class_category, dtb_class_name, dtb_product_image, mtb_sale_type | |
+| **カテゴリ** | dtb_category, dtb_product_category | |
+| **受注** | dtb_order, dtb_shipping, dtb_order_item | |
+| **支払い方法** | dtb_payment | データは移行するが**非表示**設定 |
+| **配送方法** | dtb_delivery, dtb_delivery_fee, dtb_delivery_time | データは移行するが**非表示**設定 |
+| **税設定** | dtb_tax_rule | |
 
-- dtb_customer
-- dtb_customer_address
-- mtb_sex
-- mtb_job
+## 他プラグイン連携
 
-### 管理者データ
+| プラグイン | 内容 |
+|---|---|
+| [メルマガ管理プラグイン](https://www.ec-cube.net/products/detail.php?product_id=1760) | 会員のメールマガジン送付設定を移行 |
+| [ポイントプラグイン](https://www.ec-cube.net/products/detail.php?product_id=1101) | 会員のポイントを移行（2.x のみ対応） |
+| [ECCUBE2Downloads](https://www.ec-cube.net/products/detail.php?product_id=2935) | ダウンロード商品の移行に対応（下記参照） |
 
-- dtb_member
-- mtb_authority
+### ダウンロード商品の移行（ECCUBE2Downloads 連携）
 
-### 商品データ
+[ECCUBE2Downloads プラグイン](https://www.ec-cube.net/products/detail.php?product_id=2935) がインストールされている場合、2.x のダウンロード商品を移行できます。
 
-- dtb_product
-- dtb_product_class
-- dtb_class_category
-- dtb_class_name
-- dtb_product_image
-- mtb_sale_type
+- 2.x の `mtb_product_type` から「ダウンロード」販売種別を自動検出
+- `dtb_product_class` と `dtb_delivery` の `sale_type_id` を ECCUBE2Downloads の販売種別ID（222）に書き換え
+- `down_filename` / `down_realfilename` も自動的に移行
 
-### カテゴリデータ
+ECCUBE2Downloads がインストールされていない場合、ダウンロード商品は移行されません。
 
-- dtb_category
-- dtb_product_category
+## 移行できないデータ
 
-### 受注データ
+- カート（dtb_cart, dtb_cart_item）
+- 決済と配送の紐づけ（dtb_payment_option）
+- 決済モジュール
+- 複数配送の受注データ
+- ダウンロード商品の受注データ
 
-- dtb_order
-- dtb_shipping
-- dtb_order_item
+## 注意事項
 
-### 支払い方法
+### 環境・設定
 
-- dtb_payment ※データは移行するが非表示設定
+- アップロードファイルの最大容量は PHP の設定に依存します（`memory_limit`, `post_max_size`, `upload_max_filesize`）
+- PostgreSQL の場合は super user 権限が必要です
+- プラグイン内で composer を使用しているため、オーナーズストア経由のインストールが必要です
 
-### 配送方法
+### 移行時の制約
 
-- dtb_delivery ※データは移行するが非表示設定
-- dtb_delivery_fee
-- dtb_delivery_time
-
-### 税設定
-
-- dtb_tax_rule
-
-### :point_right: 他プラグイン連携
-
-- 会員データ メールマガジン送付について [メルマガ管理プラグイン](https://www.ec-cube.net/products/detail.php?product_id=1760)
-- 会員データ ポイント [ポイントプラグイン](https://www.ec-cube.net/products/detail.php?product_id=1101)
-
-## :cloud: 移行出来ないデータ
-
-### カート
-
-- dtb_cart
-- dtb_cart_item
-
-### 決済と配送の紐づけ
-
-- dtb_payment_option
-
-### 決済モジュール
-
-## :exclamation: 注意点 1
-
-- アップロードファイルの最大容量は PHP の設定に依存します。(memory_limit, post_max_size, upload_max_filesize)
-- PostgreSQL の場合は、super user 権限が必要になります
-- 古い EC-CUBE からの移行の場合、`eccube_password_hash_algos: SHA256`を変更する必要があります
-- PostgreSQL の場合は、super user 権限が必要になります
-- プラグイン内で composer を使用しているため、オーナーズストア経由のインストールが必要になります
+- 古い EC-CUBE からの移行の場合、`eccube_password_hash_algos: SHA256` を変更する必要があります
+- 支払い方法は受注との紐づけのため移行されますが、有効化して利用することはできません。新規に作成することを推奨します
 - 新規に使う支払い方法と配送方法を設定する必要があります
-- 複数配送は移行できません
-- ダウンロード商品の受注データは移行できません
-- ダウンロード商品も移行できません
-- 支払方法は、受注との紐づけのため移行されますが、有効化して利用することはできません。新規に作成することを推奨します。
-- ポイントの移行は、EC-CUBE2 系のみ対応しています。3 系は今後対応予定です。
-- ポイントは、受注時点の 1pt あたりの金額が判別できないため、1pt ＝ 1 円として計算しています。
-- パラメータ設定で`POINT_VALUE`を変更している場合、正確な金額を移行することができません。
-- 存在しない受注ステータスを利用している受注は、受注ステータスが null の状態で移行されます。受注検索画面では表示されないため、移行後に適切な受注ステータスを紐付ける必要があります。
 
-## :exclamation: 注意点 2
+### ポイントについて
 
-4.0,4.1 から 4.3 への移行は**すべてのデータ**を移行します。
+- ポイントの移行は EC-CUBE 2.x のみ対応しています（3.x は今後対応予定）
+- ポイントは受注時点の 1pt あたりの金額が判別できないため、1pt = 1円として計算しています
+- パラメータ設定で `POINT_VALUE` を変更している場合、正確な金額を移行できません
+
+### 受注ステータスについて
+
+- 存在しない受注ステータスを利用している受注は、受注ステータスが null の状態で移行されます
+- 受注検索画面では表示されないため、移行後に適切な受注ステータスを紐付ける必要があります
+
+### 4.0 / 4.1 からの移行
+
+4.0 / 4.1 から 4.3 への移行は**すべてのデータ**を移行します。
 
 ## License
 

--- a/Tests/Web/Admin/ConfigControllerTest.php
+++ b/Tests/Web/Admin/ConfigControllerTest.php
@@ -117,13 +117,6 @@ class ConfigControllerTest extends AbstractAdminWebTestCase
         $project_dir = $container->getParameter('kernel.project_dir');
         $conn = $this->entityManager->getConnection();
 
-        // ECCUBE2Downloadsプラグインをインストール済みとしてdtb_pluginに登録
-        $now = (new \DateTime())->format('Y-m-d H:i:s');
-        $conn->executeStatement(
-            "INSERT INTO dtb_plugin (name, code, enabled, version, source, initialized, create_date, update_date) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-            ['ECCUBE2Downloads', 'ECCUBE2Downloads', false, '1.0.0', '', false, $now, $now]
-        );
-
         $file = $project_dir . '/app/Plugin/DataMigration43/Tests/Fixtures/2_13_5.tar.gz';
         $testFile = $project_dir . '/app/Plugin/DataMigration43/Tests/Fixtures/test.tar.gz';
 
@@ -169,21 +162,18 @@ class ConfigControllerTest extends AbstractAdminWebTestCase
             );
             self::assertEquals(222, (int)$delivSaleTypeId, 'ダウンロード配送のsale_type_idが222であること');
 
-            // down_filename, down_realfilenameが移行されていること（ECCUBE2Downloadsがインストールされている場合のみカラムが存在する）
-            $columns = $conn->fetchFirstColumn("SELECT column_name FROM information_schema.columns WHERE table_name = 'dtb_product_class' AND column_name = 'down_filename'");
-            if (!empty($columns)) {
-                $downFilename = $conn->fetchOne(
-                    "SELECT down_filename FROM dtb_product_class WHERE product_id = ? AND visible = 1",
-                    [3]
-                );
-                self::assertEquals('おなべレシピ.pdf', $downFilename, 'down_filenameが移行されていること');
+            // down_filename, down_realfilenameが移行されていること
+            $downFilename = $conn->fetchOne(
+                "SELECT down_filename FROM dtb_product_class WHERE product_id = ? AND visible = 1",
+                [3]
+            );
+            self::assertEquals('おなべレシピ.pdf', $downFilename, 'down_filenameが移行されていること');
 
-                $downRealfilename = $conn->fetchOne(
-                    "SELECT down_realfilename FROM dtb_product_class WHERE product_id = ? AND visible = 1",
-                    [3]
-                );
-                self::assertEquals('recipe_onabe.pdf', $downRealfilename, 'down_realfilenameが移行されていること');
-            }
+            $downRealfilename = $conn->fetchOne(
+                "SELECT down_realfilename FROM dtb_product_class WHERE product_id = ? AND visible = 1",
+                [3]
+            );
+            self::assertEquals('recipe_onabe.pdf', $downRealfilename, 'down_realfilenameが移行されていること');
         } catch (\Exception $e) {
             if ($this->entityManager->getConnection()->isTransactionActive()) {
                 $this->entityManager->getConnection()->rollBack();

--- a/Tests/Web/Admin/ConfigControllerTest.php
+++ b/Tests/Web/Admin/ConfigControllerTest.php
@@ -169,18 +169,21 @@ class ConfigControllerTest extends AbstractAdminWebTestCase
             );
             self::assertEquals(222, (int)$delivSaleTypeId, 'ダウンロード配送のsale_type_idが222であること');
 
-            // down_filename, down_realfilenameが移行されていること
-            $downFilename = $conn->fetchOne(
-                "SELECT down_filename FROM dtb_product_class WHERE product_id = ? AND visible = 1",
-                [3]
-            );
-            self::assertEquals('おなべレシピ.pdf', $downFilename, 'down_filenameが移行されていること');
+            // down_filename, down_realfilenameが移行されていること（ECCUBE2Downloadsがインストールされている場合のみカラムが存在する）
+            $columns = $conn->fetchFirstColumn("SELECT column_name FROM information_schema.columns WHERE table_name = 'dtb_product_class' AND column_name = 'down_filename'");
+            if (!empty($columns)) {
+                $downFilename = $conn->fetchOne(
+                    "SELECT down_filename FROM dtb_product_class WHERE product_id = ? AND visible = 1",
+                    [3]
+                );
+                self::assertEquals('おなべレシピ.pdf', $downFilename, 'down_filenameが移行されていること');
 
-            $downRealfilename = $conn->fetchOne(
-                "SELECT down_realfilename FROM dtb_product_class WHERE product_id = ? AND visible = 1",
-                [3]
-            );
-            self::assertEquals('recipe_onabe.pdf', $downRealfilename, 'down_realfilenameが移行されていること');
+                $downRealfilename = $conn->fetchOne(
+                    "SELECT down_realfilename FROM dtb_product_class WHERE product_id = ? AND visible = 1",
+                    [3]
+                );
+                self::assertEquals('recipe_onabe.pdf', $downRealfilename, 'down_realfilenameが移行されていること');
+            }
         } catch (\Exception $e) {
             if ($this->entityManager->getConnection()->isTransactionActive()) {
                 $this->entityManager->getConnection()->rollBack();

--- a/Tests/Web/Admin/ConfigControllerTest.php
+++ b/Tests/Web/Admin/ConfigControllerTest.php
@@ -143,14 +143,14 @@ class ConfigControllerTest extends AbstractAdminWebTestCase
 
             // ダウンロード商品(product_id=3)のsale_type_idが222であること
             $saleTypeId = $conn->fetchOne(
-                "SELECT sale_type_id FROM dtb_product_class WHERE product_id = ? AND visible = 1",
+                "SELECT sale_type_id FROM dtb_product_class WHERE product_id = ? AND visible = true",
                 [3]
             );
             self::assertEquals(222, (int)$saleTypeId, 'ダウンロード商品のsale_type_idが222であること');
 
             // 通常商品(product_id=1)のsale_type_idが222でないこと
             $normalSaleTypeId = $conn->fetchOne(
-                "SELECT sale_type_id FROM dtb_product_class WHERE product_id = ? AND visible = 1 LIMIT 1",
+                "SELECT sale_type_id FROM dtb_product_class WHERE product_id = ? AND visible = true LIMIT 1",
                 [1]
             );
             self::assertNotEquals(222, (int)$normalSaleTypeId, '通常商品のsale_type_idは222でないこと');
@@ -164,13 +164,13 @@ class ConfigControllerTest extends AbstractAdminWebTestCase
 
             // down_filename, down_realfilenameが移行されていること
             $downFilename = $conn->fetchOne(
-                "SELECT down_filename FROM dtb_product_class WHERE product_id = ? AND visible = 1",
+                "SELECT down_filename FROM dtb_product_class WHERE product_id = ? AND visible = true",
                 [3]
             );
             self::assertEquals('おなべレシピ.pdf', $downFilename, 'down_filenameが移行されていること');
 
             $downRealfilename = $conn->fetchOne(
-                "SELECT down_realfilename FROM dtb_product_class WHERE product_id = ? AND visible = 1",
+                "SELECT down_realfilename FROM dtb_product_class WHERE product_id = ? AND visible = true",
                 [3]
             );
             self::assertEquals('recipe_onabe.pdf', $downRealfilename, 'down_realfilenameが移行されていること');

--- a/Tests/Web/Admin/ConfigControllerTest.php
+++ b/Tests/Web/Admin/ConfigControllerTest.php
@@ -106,4 +106,87 @@ class ConfigControllerTest extends AbstractAdminWebTestCase
             throw $e;
         }
     }
+
+    /**
+     * ECCUBE2Downloadsプラグインがインストール済みの場合、
+     * ダウンロード商品のsale_type_idが222に書き換わることをテスト
+     */
+    public function testECCUBE2Downloadsダウンロード商品のsale_type_idが222になる()
+    {
+        $container = self::getContainer();
+        $project_dir = $container->getParameter('kernel.project_dir');
+        $conn = $this->entityManager->getConnection();
+
+        // ECCUBE2Downloadsプラグインをインストール済みとしてdtb_pluginに登録
+        $now = (new \DateTime())->format('Y-m-d H:i:s');
+        $conn->executeStatement(
+            "INSERT INTO dtb_plugin (name, code, enabled, version, source, initialized, create_date, update_date) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            ['ECCUBE2Downloads', 'ECCUBE2Downloads', false, '1.0.0', '', false, $now, $now]
+        );
+
+        $file = $project_dir . '/app/Plugin/DataMigration43/Tests/Fixtures/2_13_5.tar.gz';
+        $testFile = $project_dir . '/app/Plugin/DataMigration43/Tests/Fixtures/test.tar.gz';
+
+        $fs = new Filesystem();
+        $fs->copy($file, $testFile);
+
+        $file = new UploadedFile($testFile, 'test.tar.gz', 'application/x-tar', null, true);
+
+        $post = [
+            'config' => [
+                Constant::TOKEN_NAME => 'dummy',
+                'import_file' => $file,
+                'auth_magic' => 'dummy',
+            ]
+        ];
+
+        try {
+            $this->client->request(
+                'POST',
+                $this->generateUrl('data_migration43_admin_config'),
+                $post,
+                ['config' => ['import_file' => $file]]
+            );
+
+            // ダウンロード商品(product_id=3)のsale_type_idが222であること
+            $saleTypeId = $conn->fetchOne(
+                "SELECT sale_type_id FROM dtb_product_class WHERE product_id = ? AND visible = 1",
+                [3]
+            );
+            self::assertEquals(222, (int)$saleTypeId, 'ダウンロード商品のsale_type_idが222であること');
+
+            // 通常商品(product_id=1)のsale_type_idが222でないこと
+            $normalSaleTypeId = $conn->fetchOne(
+                "SELECT sale_type_id FROM dtb_product_class WHERE product_id = ? AND visible = 1 LIMIT 1",
+                [1]
+            );
+            self::assertNotEquals(222, (int)$normalSaleTypeId, '通常商品のsale_type_idは222でないこと');
+
+            // ダウンロード配送(product_type_id=2)のdeliveryのsale_type_idが222であること
+            $delivSaleTypeId = $conn->fetchOne(
+                "SELECT sale_type_id FROM dtb_delivery WHERE id = ?",
+                [2]
+            );
+            self::assertEquals(222, (int)$delivSaleTypeId, 'ダウンロード配送のsale_type_idが222であること');
+
+            // down_filename, down_realfilenameが移行されていること
+            $downFilename = $conn->fetchOne(
+                "SELECT down_filename FROM dtb_product_class WHERE product_id = ? AND visible = 1",
+                [3]
+            );
+            self::assertEquals('おなべレシピ.pdf', $downFilename, 'down_filenameが移行されていること');
+
+            $downRealfilename = $conn->fetchOne(
+                "SELECT down_realfilename FROM dtb_product_class WHERE product_id = ? AND visible = 1",
+                [3]
+            );
+            self::assertEquals('recipe_onabe.pdf', $downRealfilename, 'down_realfilenameが移行されていること');
+        } catch (\Exception $e) {
+            if ($this->entityManager->getConnection()->isTransactionActive()) {
+                $this->entityManager->getConnection()->rollBack();
+                $this->entityManager->getConnection()->beginTransaction();
+            }
+            throw $e;
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ec-cube/datamigration43",
-    "version": "4.3.6",
+    "version": "4.3.7",
     "description": "データ移行プラグイン",
     "type": "eccube-plugin",
     "require": {


### PR DESCRIPTION
## Summary

- ECCUBE2Downloadsプラグインがインストール済みの場合、2.xバックアップの `mtb_product_type.csv` から「ダウンロード」販売種別のIDを検出
- `dtb_product_class` 及び `dtb_delivery` の `sale_type_id` を 222（ECCUBE2Downloadsの販売種別ID）にマッピング
- `down_filename` / `down_realfilename` は既存の汎用マッピングロジックで自動移行される（追加コード不要）

## Test plan

- [ ] ECCUBE2Downloadsプラグインを有効化した状態でDataMigration43のテストを実行
- [ ] ダウンロード商品を含む2.xバックアップを移行し、`dtb_product_class` の `sale_type_id` が222になることを確認
- [ ] 通常商品の `sale_type_id` が222にならないことを確認
- [ ] `dtb_delivery` のダウンロード配送の `sale_type_id` が222になることを確認
- [ ] `down_filename`, `down_realfilename` が移行されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)