### PR TITLE
省メモリ化: スキーマキャッシュ・不要データ削減・フェーズ間メモリ解放

### DIFF
--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -159,8 +159,11 @@ class ConfigController extends AbstractController
 
                     // 全データ移行
                     $this->saveCustomer($em, $csvDir);
+                    $this->releaseCustomerPhaseMemory();
                     $this->saveProduct($em, $csvDir);
+                    $this->releaseProductPhaseMemory();
                     $this->saveOrder($em, $csvDir);
+                    $this->releaseOrderPhaseMemory();
                 }
 
                 // plg_customerplusの移行処理を作る
@@ -1832,8 +1835,10 @@ class ConfigController extends AbstractController
                             }
                         }
 
-                        // shippingに紐付けるデータを保持
-                        $this->shipping_order[$data['id']] = $data;
+                        // shippingに紐付けるデータを保持（必要なフィールドのみ）
+                        $this->shipping_order[$data['id']] = [
+                            'commit_date' => $data['commit_date'] ?? null,
+                        ];
 
                         break;
 
@@ -2342,5 +2347,31 @@ class ConfigController extends AbstractController
 
             return $i; // indexを返す
         }
+    }
+
+    private function releaseCustomerPhaseMemory(): void
+    {
+        $this->customer_point = [];
+        gc_collect_cycles();
+    }
+
+    private function releaseProductPhaseMemory(): void
+    {
+        $this->stock = [];
+        $this->product_images = [];
+        $this->dtb_class_combination = [];
+        $this->delivery_id = [];
+        $this->product_class_id = [];
+        gc_collect_cycles();
+    }
+
+    private function releaseOrderPhaseMemory(): void
+    {
+        $this->order_item = [];
+        $this->shipping_id = [];
+        $this->shipping_order = [];
+        $this->tax_rule = [];
+        $this->delivery_time = [];
+        gc_collect_cycles();
     }
 }

--- a/Service/DataMigrationService.php
+++ b/Service/DataMigrationService.php
@@ -45,6 +45,12 @@ class DataMigrationService
     private $mappingCache = [];
 
     /**
+     * テーブルカラム情報のキャッシュ（テーブル名 => カラム配列）
+     * @var array
+     */
+    private $tableColumnsCache = [];
+
+    /**
      * Customer item option data for migration
      * @var array
      */
@@ -178,7 +184,10 @@ class DataMigrationService
 
 
         try {
-            $columns = $em->getSchemaManager()->listTableColumns($tableName);
+            if (!isset($this->tableColumnsCache[$tableName])) {
+                $this->tableColumnsCache[$tableName] = $em->getSchemaManager()->listTableColumns($tableName);
+            }
+            $columns = $this->tableColumnsCache[$tableName];
             $hasConversion = false;
 
             foreach ($data as $key => &$value) {


### PR DESCRIPTION
## Summary
- テーブルカラム情報のスキーマキャッシュ導入で重複クエリを削減
- shipping_orderに必要フィールドのみ保持しメモリ使用量を削減
- フェーズ間（会員→商品→受注）でメモリ解放を実施

## Test plan
- [x] CI全テスト通過済み（2月8日時点）
- [ ] CI再実行で全テスト通過を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)