### PR TITLE
fix: AUTH_MAGIC入力バリデーション追加（.envインジェクション対策）

### DIFF
--- a/Form/Type/Admin/ConfigType.php
+++ b/Form/Type/Admin/ConfigType.php
@@ -9,6 +9,7 @@ use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\Validator\Constraints\File;
 use Symfony\Component\Validator\Constraints\NotBlank;
+use Symfony\Component\Validator\Constraints\Regex;
 
 class ConfigType extends AbstractType
 {
@@ -36,9 +37,15 @@ class ConfigType extends AbstractType
             ->add('auth_magic', TextType::class, [
                 'label' => 'AUTH_MAGIC',
                 'required' => true,
-                //'placeholder' => '',
                 'attr' => [
                     'placeholder' => "旧サイトのAUTH_MAGICを入力してください。",
+                ],
+                'constraints' => [
+                    new NotBlank(['message' => 'AUTH_MAGICを入力してください。']),
+                    new Regex([
+                        'pattern' => '/^[a-zA-Z0-9_\-\.]+$/',
+                        'message' => 'AUTH_MAGICには英数字、アンダースコア、ハイフン、ドットのみ使用できます。',
+                    ]),
                 ],
             ])
         ;

--- a/Service/DataMigrationService.php
+++ b/Service/DataMigrationService.php
@@ -120,6 +120,12 @@ class DataMigrationService
 
     public function updateEnv($newMagicValue)
     {
+        // 改行を除去し、安全な文字のみ許可（.envインジェクション対策）
+        $newMagicValue = str_replace(["\r", "\n"], '', $newMagicValue);
+        if (!preg_match('/^[a-zA-Z0-9_\-\.]+$/', $newMagicValue)) {
+            throw new \InvalidArgumentException('AUTH_MAGIC に使用できない文字が含まれています。');
+        }
+
         $projectDir = $this->params->get('kernel.project_dir');
         $envFile = $projectDir . '/.env';
 


### PR DESCRIPTION
## Summary

- `auth_magic` フィールドに改行文字を含む値を送信すると `updateEnv()` の `preg_replace` で `.env` ファイルに任意の環境変数（`DATABASE_URL` 等）を注入可能な脆弱性を修正
- **ConfigType**: `auth_magic` に `NotBlank` + `Regex(/^[a-zA-Z0-9_\-\.]+$/)` 制約を追加
- **DataMigrationService::updateEnv()**: 改行除去 + パターン検証を追加（フォームを経由しない直接呼び出しにも対応する二重防御）

## Background

PR #21 で試みた AUTH_MAGIC バリデーションの再実装。PR #21 はメンバーUPSERT修正・テスト追加を含みすぎて複雑化しクローズされた。PR #26 で member UPSERT 修正は完了済みのため、バリデーションのみに集中。

## Test plan

- [ ] CI の既存テスト (`auth_magic => 'dummy'`) が引き続き通ること（`dummy` は許可パターンにマッチ）
- [ ] 改行を含む `auth_magic` がフォームバリデーションで拒否されること
- [ ] `updateEnv()` に直接不正値を渡した場合に `InvalidArgumentException` がスローされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)