### PR TITLE
fix: error_logからCSV行データ(PII含む)の出力を除去

### DIFF
--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -436,8 +436,6 @@ class ConfigController extends AbstractController
                         $builder->execute();
                     } catch (\Exception $e) {
                         error_log("BulkInsertQuery execute error in saveToC table '$tableName' at row $i: " . $e->getMessage());
-                        error_log("Failed data for row $i: " . json_encode($value));
-                        error_log("Original CSV data: " . json_encode($data));
                         throw $e;
                     }
                 }

--- a/Service/DataMigrationService.php
+++ b/Service/DataMigrationService.php
@@ -203,7 +203,6 @@ class DataMigrationService
             }
         } catch (\Exception $e) {
             error_log("Error in convertDataTypesForPostgreSQL for table '$tableName': " . $e->getMessage());
-            error_log("Data being processed: " . json_encode($data));
             // エラーが発生した場合は元のデータをそのまま返す
         }
 


### PR DESCRIPTION
## Summary

- `saveToC()` の catch ブロックで `json_encode($value)` / `json_encode($data)` をログ出力していた行を削除
- `convertDataTypesForPostgreSQL()` の catch ブロックで `json_encode($data)` をログ出力していた行を削除
- テーブル名・行番号・例外メッセージのログは維持（デバッグ情報は確保）

## Background

CSVには顧客パスワードハッシュ・メールアドレス等のPIIが含まれる。`error_log` でCSV行データを丸ごと出力すると、ログファイルにPIIが永続し、サーバー運用担当者やホスティング事業者等にも見える状態になる。

## Test plan

- [ ] CI の既存テストが通ること
- [ ] エラー発生時にテーブル名・行番号・例外メッセージはログに記録されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)