### PR TITLE
fix: SQL識別子のエスケープ処理をquoteIdentifierに統一

### DIFF
--- a/Controller/Admin/ConfigController.php
+++ b/Controller/Admin/ConfigController.php
@@ -966,7 +966,7 @@ class ConfigController extends AbstractController
             $updateSql = implode(', ', array_map(function ($c) {
                 return '"' . $c . '" = EXCLUDED."' . $c . '"';
             }, $updateCols));
-            $sql = 'INSERT INTO ' . $tableName . ' (' . $colsSql . ') VALUES (' . $placeholders . ') ON CONFLICT (id) DO UPDATE SET ' . $updateSql;
+            $sql = 'INSERT INTO ' . $em->quoteIdentifier($tableName) . ' (' . $colsSql . ') VALUES (' . $placeholders . ') ON CONFLICT (id) DO UPDATE SET ' . $updateSql;
             $em->prepare($sql)->executeStatement(array_values($insertValues));
             $rowCount++;
         }
@@ -1397,7 +1397,7 @@ class ConfigController extends AbstractController
         $builder = new BulkInsertQuery($em, $tableName);
         $builder->setColumns($listTableColumns);
 
-        $em->exec('DELETE FROM ' . $tableName);
+        $em->exec('DELETE FROM ' . $em->quoteIdentifier($tableName));
 
         $i = 1;
         $batchSize = 20;
@@ -1436,7 +1436,7 @@ class ConfigController extends AbstractController
         $builder = new BulkInsertQuery($em, $tableName);
         $builder->setColumns($listTableColumns);
 
-        $em->exec('DELETE FROM ' . $tableName);
+        $em->exec('DELETE FROM ' . $em->quoteIdentifier($tableName));
 
         $i = 1;
         $batchSize = 20;
@@ -2037,7 +2037,7 @@ class ConfigController extends AbstractController
         $builder = new BulkInsertQuery($em, $tableName);
         $builder->setColumns($listTableColumns);
 
-        $i = $em->fetchOne('SELECT max(id) + 1  FROM ' . $tableName);
+        $i = $em->fetchOne('SELECT max(id) + 1  FROM ' . $em->quoteIdentifier($tableName));
         $batchSize = 20;
         foreach ($this->order_item as $order_id => $type) {
             foreach ($type as $key => $value) {
@@ -2296,7 +2296,7 @@ class ConfigController extends AbstractController
                         $updateSet = array_map(fn($c) => '"' . $c . '" = EXCLUDED."' . $c . '"', $updateCols);
                         $conflictCols = array_map(fn($c) => '"' . $c . '"', $primaryKeys);
 
-                        $sql = 'INSERT INTO "' . $tableName . '" (' . implode(', ', $cols) . ') ' .
+                        $sql = 'INSERT INTO ' . $em->quoteIdentifier($tableName) . ' (' . implode(', ', $cols) . ') ' .
                                'VALUES (' . implode(', ', $placeholders) . ') ' .
                                'ON CONFLICT (' . implode(', ', $conflictCols) . ') ' .
                                'DO UPDATE SET ' . implode(', ', $updateSet);

--- a/Service/DataMigrationService.php
+++ b/Service/DataMigrationService.php
@@ -136,19 +136,21 @@ class DataMigrationService
         file_put_contents($envFile, $env);
     }
 
+    /**
+     * テーブル名のバリデーション
+     */
+    private function validateTableName(string $tableName): void
+    {
+        if (!preg_match('/^[a-zA-Z_][a-zA-Z0-9_]{0,63}$/', $tableName)) {
+            throw new \InvalidArgumentException('Invalid table name: ' . $tableName);
+        }
+    }
+
     public function resetTable(Connection $em, $tableName)
     {
-        $platform = $em->getDatabasePlatform()->getName();
-
-        if ($platform == 'mysql') {
-            $em->exec('DELETE FROM ' . $tableName);
-        } elseif ($platform == 'postgresql') {
-            // PostgreSQLでは fix4x() はUPSERTを使うため、このメソッドは呼ばれない
-            // saveToC() などから呼ばれる場合はDELETEを実行
-            $em->exec('DELETE FROM "' . $tableName . '"');
-        } else {
-            $em->exec('DELETE FROM ' . $tableName);
-        }
+        $this->validateTableName($tableName);
+        $quoted = $em->quoteIdentifier($tableName);
+        $em->exec('DELETE FROM ' . $quoted);
     }
 
     public function convertNULL($data)
@@ -305,7 +307,7 @@ class DataMigrationService
                 foreach ($targetTables as $t) {
                     $exists = $em->fetchOne("SELECT 1 FROM pg_tables WHERE schemaname='public' AND tablename=?", [$t]);
                     if ($exists) {
-                        $existing[] = '"' . str_replace('"', '""', $t) . '"';
+                        $existing[] = $em->quoteIdentifier($t);
                     }
                 }
                 if ($existing) {
@@ -324,11 +326,13 @@ class DataMigrationService
 
     public function setIdSeq($em, $tableName)
     {
-        $max = $em->fetchOne('SELECT coalesce(max(id), 0) + 1  FROM ' . $tableName);
+        $this->validateTableName($tableName);
+        $quoted = $em->quoteIdentifier($tableName);
+        $max = $em->fetchOne('SELECT coalesce(max(id), 0) + 1  FROM ' . $quoted);
         $seq = $tableName . '_id_seq';
-        $count = $em->fetchOne("select count(*) from pg_class where relname = '$seq';");
+        $count = $em->fetchOne("select count(*) from pg_class where relname = ?", [$seq]);
         if ($count) {
-            $em->exec("SELECT setval('$seq', $max);");
+            $em->executeStatement("SELECT setval(?, ?)", [$seq, $max]);
         }
     }
 


### PR DESCRIPTION
## Summary

- テーブル名をSQL文に直接結合していた箇所を DBAL の `quoteIdentifier()` に統一
- `DataMigrationService` に `validateTableName()` を追加（正規表現 `/^[a-zA-Z_][a-zA-Z0-9_]{0,63}$/`）
- `setIdSeq()` のシーケンス名・値もプリペアドステートメントに変更

### 修正箇所

| ファイル | メソッド | 修正内容 |
|---|---|---|
| `DataMigrationService` | `resetTable()` | validate + `quoteIdentifier` に統一、DB分岐を除去 |
| `DataMigrationService` | `setIdSeq()` | validate + `quoteIdentifier` + prepared statement |
| `DataMigrationService` | `begin()` | 手動 `str_replace` → `quoteIdentifier` |
| `ConfigController` | `saveStock()` | `DELETE FROM` に `quoteIdentifier` |
| `ConfigController` | `saveProductImage()` | 同上 |
| `ConfigController` | `saveOrderItem()` | `SELECT max(id)` に `quoteIdentifier` |
| `ConfigController` | `upsertMasterFromCsv()` | `INSERT INTO` に `quoteIdentifier` |
| `ConfigController` | `fix4x()` | `INSERT INTO` の手動クォート → `quoteIdentifier` |

## Test plan

- [ ] CI の全テスト（MySQL/MySQL8/PostgreSQL × 各PHPバージョン）が通ること

🤖 Generated with [Claude Code](https://claude.com/claude-code)